### PR TITLE
Added callback calls after model sync actions are performed

### DIFF
--- a/sync/ajax.js
+++ b/sync/ajax.js
@@ -124,7 +124,7 @@ mvc.AjaxSync.prototype.del = function(model, opt_callback) {
 mvc.AjaxSync.prototype.onCreateComplete_ = function(model, callback, e) {
   var xhr = e.target;
   model.set('id', xhr.getResponseJson()['result']['id']);
-	callback();
+  callback.call(model);
 };
 
 
@@ -140,7 +140,7 @@ mvc.AjaxSync.prototype.onReadComplete_ = function(model, callback, e) {
   var xhr = e.target;
   var json = xhr.getResponseJson()['result'];
   model.set(json);
-	callback();
+  callback.call(model);
 };
 
 
@@ -153,7 +153,7 @@ mvc.AjaxSync.prototype.onReadComplete_ = function(model, callback, e) {
  * @param {Event} e the completed xhr event.
  */
 mvc.AjaxSync.prototype.onUpdateComplete_ = function(model, callback, e) {
-	callback();
+  callback.call(model);
 };
 
 
@@ -166,5 +166,5 @@ mvc.AjaxSync.prototype.onUpdateComplete_ = function(model, callback, e) {
  * @param {Event} e the completed xhr event.
  */
 mvc.AjaxSync.prototype.onDelComplete_ = function(model, callback, e) {
-	callback();
+  callback.call(model);
 };

--- a/sync/ajax.js
+++ b/sync/ajax.js
@@ -124,6 +124,7 @@ mvc.AjaxSync.prototype.del = function(model, opt_callback) {
 mvc.AjaxSync.prototype.onCreateComplete_ = function(model, callback, e) {
   var xhr = e.target;
   model.set('id', xhr.getResponseJson()['result']['id']);
+	callback();
 };
 
 
@@ -139,6 +140,7 @@ mvc.AjaxSync.prototype.onReadComplete_ = function(model, callback, e) {
   var xhr = e.target;
   var json = xhr.getResponseJson()['result'];
   model.set(json);
+	callback();
 };
 
 
@@ -151,6 +153,7 @@ mvc.AjaxSync.prototype.onReadComplete_ = function(model, callback, e) {
  * @param {Event} e the completed xhr event.
  */
 mvc.AjaxSync.prototype.onUpdateComplete_ = function(model, callback, e) {
+	callback();
 };
 
 
@@ -163,4 +166,5 @@ mvc.AjaxSync.prototype.onUpdateComplete_ = function(model, callback, e) {
  * @param {Event} e the completed xhr event.
  */
 mvc.AjaxSync.prototype.onDelComplete_ = function(model, callback, e) {
+	callback();
 };

--- a/sync/local.js
+++ b/sync/local.js
@@ -34,9 +34,9 @@ mvc.LocalSync.prototype.getUID = function() {
 mvc.LocalSync.prototype.create = function(model, opt_callback) {
   var id = this.getUID();
   model.set('id', id);
-	if (goog.isFunction(opt_callback)) {
-		opt_callback();
-	}
+  if (goog.isFunction(opt_callback)) {
+    opt_callback.call(model);
+  }
 };
 
 
@@ -46,9 +46,9 @@ mvc.LocalSync.prototype.create = function(model, opt_callback) {
 mvc.LocalSync.prototype.read = function(model, opt_callback) {
   model.set(/** @type {Object} */(this.store_.get(
       /** @type {string} */(model.get('id')))));
-	if (goog.isFunction(opt_callback)) {
-		opt_callback();
-	}
+  if (goog.isFunction(opt_callback)) {
+    opt_callback.call(model);
+  }
 };
 
 
@@ -57,9 +57,9 @@ mvc.LocalSync.prototype.read = function(model, opt_callback) {
  */
 mvc.LocalSync.prototype.update = function(model, opt_callback) {
   this.store_.set(/** @type {string} */(model.get('id')), model.toJson());
-	if (goog.isFunction(opt_callback)) {
-		opt_callback();
-	}
+  if (goog.isFunction(opt_callback)) {
+    opt_callback.call(model);
+  }
 };
 
 
@@ -68,7 +68,7 @@ mvc.LocalSync.prototype.update = function(model, opt_callback) {
  */
 mvc.LocalSync.prototype.del = function(model, opt_callback) {
   this.store_.remove(/** @type {string} */(model.get('id')));
-	if (goog.isFunction(opt_callback)) {
-		opt_callback();
-	}
+  if (goog.isFunction(opt_callback)) {
+    opt_callback.call(model);
+  }
 };

--- a/sync/local.js
+++ b/sync/local.js
@@ -34,6 +34,9 @@ mvc.LocalSync.prototype.getUID = function() {
 mvc.LocalSync.prototype.create = function(model, opt_callback) {
   var id = this.getUID();
   model.set('id', id);
+	if (goog.isFunction(opt_callback)) {
+		opt_callback();
+	}
 };
 
 
@@ -43,6 +46,9 @@ mvc.LocalSync.prototype.create = function(model, opt_callback) {
 mvc.LocalSync.prototype.read = function(model, opt_callback) {
   model.set(/** @type {Object} */(this.store_.get(
       /** @type {string} */(model.get('id')))));
+	if (goog.isFunction(opt_callback)) {
+		opt_callback();
+	}
 };
 
 
@@ -51,6 +57,9 @@ mvc.LocalSync.prototype.read = function(model, opt_callback) {
  */
 mvc.LocalSync.prototype.update = function(model, opt_callback) {
   this.store_.set(/** @type {string} */(model.get('id')), model.toJson());
+	if (goog.isFunction(opt_callback)) {
+		opt_callback();
+	}
 };
 
 
@@ -59,4 +68,7 @@ mvc.LocalSync.prototype.update = function(model, opt_callback) {
  */
 mvc.LocalSync.prototype.del = function(model, opt_callback) {
   this.store_.remove(/** @type {string} */(model.get('id')));
+	if (goog.isFunction(opt_callback)) {
+		opt_callback();
+	}
 };


### PR DESCRIPTION
Callbacks were passed to sync functions, but not called anywhere in them. Now they are called in both implementations of sync interface.
