### PR TITLE
Add non-capturing group to route.

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ so for /note=1234567890/edit/message?abc=123 will give:
 
 ```javascript
 function(fragment,id,edit,entity,query,queryVals) {
-    console.log(fragment); // /note=1234567890/edit?abc=123
+    console.log(fragment); // /note=1234567890/edit/message?abc=123
     console.log(id); // 1234567890
     console.log(edit); // /edit
     console.log(entity); // message

--- a/README.md
+++ b/README.md
@@ -501,22 +501,24 @@ The AjaxSync can be used and passed an object of functions or strings (with the 
 
 ## mvc.Router ##
 
-mvc.Router uses goog.History and hash tokens to hold and manage the state of the application. You can define a route with a regular expression that will fire custom events when a certain route comes on the URL. A route can be defined with a route expression which can take : followed by an attribute, a * to pass the rest of the route and [] for an optional part of the url (which will be passed to the function). For instance:
+mvc.Router uses goog.History and hash tokens to hold and manage the state of the application. You can define a route with a regular expression that will fire custom events when a certain route comes on the URL. A route can be defined with a route expression which can take : followed by an attribute, a * to pass the rest of the route, [] for an optional part of the url (which will be passed to the function) and {} for an optional part that will be not passed to the function. For instance:
 
 ```javascript
-route = "/note=:id[/edit][?*]";
+route = "/note=:id[/edit]{/:entity}[?*]";
 ```
-should take a function with four attribute:
+should take a function with six attribute:
 ```javascript
-function(id,edit,query,queryVals)
+function(fragment,id,edit,entity,query,queryVals)
 ```
 
-so for /note=1234567890/edit?abc=123 will give:
+so for /note=1234567890/edit/message?abc=123 will give:
 
 ```javascript
-function(id,edit,query,queryVals) {
+function(fragment,id,edit,entity,query,queryVals) {
+    console.log(fragment); // /note=1234567890/edit?abc=123
     console.log(id); // 1234567890
     console.log(edit); // /edit
+    console.log(entity); // message
     console.log(query); // ?abc=123
     console.log(queryVals); // abc=123
 }

--- a/router.js
+++ b/router.js
@@ -48,7 +48,7 @@ mvc.Router.prototype.navigate = function(fragment) {
  * argument. *abc/def will pass through all after the * as an argument
  *
  * @param {string|RegExp} route to watch for.
- * @param {Function} fn should take in the token and any captured strings.
+ * @param {function(string, ...[string])} fn should take in the token and any captured strings.
  */
 mvc.Router.prototype.route = function(route, fn) {
   if (goog.isString(route))

--- a/router.js
+++ b/router.js
@@ -56,7 +56,9 @@ mvc.Router.prototype.route = function(route, fn) {
             .replace(/\\:\w+/g, '(\\w+)')
             .replace(/\\\*/g, '(.*)')
             .replace(/\\\[/g, '(')
-            .replace(/\\\]/g, ')?') + '$');
+            .replace(/\\\]/g, ')?')
+            .replace(/\\\{/g, '(?:')
+            .replace(/\\\}/g, ')?') + '$');
   this.routes_.push({route: route, callback: fn});
 };
 

--- a/tests/router_test.js
+++ b/tests/router_test.js
@@ -29,6 +29,26 @@ var testRoute = function() {
   router.navigate('test');
 };
 
+var testRouteCapturingGroup = function() {
+    router.route('/note=:id[/edit][?*]', function (fragment, id, edit, query, queryVals) {
+        assertEquals('/note=1234567890/edit?abc=123', fragment);
+        assertEquals('1234567890', id);
+        assertEquals('/edit', edit);
+        assertEquals('?abc=123', query);
+        assertEquals('abc=123', queryVals);
+    });
+    router.navigate('/note=1234567890/edit?abc=123');
+};
+
+var testRouteNonCapturingGroup = function() {
+    router.route('/note=:id{/:operation}{?abc=:abc}', function (fragment, id, operation, abc) {
+        assertEquals('/note=1234567890/edit?abc=123', fragment);
+        assertEquals('1234567890', id);
+        assertEquals('edit', operation);
+        assertEquals('123', abc);
+    });
+    router.navigate('/note=1234567890/edit?abc=123');
+};
 
 testCase = new goog.testing.ContinuationTestCase();
 testCase.autoDiscoverTests();


### PR DESCRIPTION
I found useful to exclude some groups from capturing, this will make route handler more concise.
For example your route example can be rewritten as:

 "/note=:id{/:operation}{?abc=:abc}"

in this case handler function will have signature:

function(fragment, id,operation,abc)

and for /note=1234567890/edit?abc=123 will give result:

function(fragment, id, operation, abc) {
    console.log(fragment) // /note=1234567890/edit?abc=123 
    console.log(id); // 1234567890
    console.log(operation); // edit
    console.log(abc); // 123
}

Btw there is mistake in doc, first function argument will always be full fragment string.

Thanks, Artem.
