### PR TITLE
Routing improvements

### DIFF
--- a/router.js
+++ b/router.js
@@ -40,6 +40,17 @@ mvc.Router = function(opt_noFragment, opt_blankPage, opt_input, opt_iframe) {
   this.currentFragment_ = "";
   this.history_.setEnabled(true);
 };
+goog.inherits(mvc.Router, goog.events.EventTarget);
+
+/**
+ * router event types
+ */
+mvc.Router.EventType = {
+  /*
+   * event to trigger when route is about to change.
+   */
+  ROUTE_EXPIRED: "routeExpired"
+}
 
 /**
  * pass through the fragment for the URL
@@ -96,6 +107,7 @@ mvc.Router.prototype.runRouteIfMatches_ = function(route, fragment) {
 mvc.Router.prototype.onChange_ = function() {
   var fragment = this.history_.getToken();
   if (fragment != this.currentFragment_) {
+    this.dispatchEvent({type: mvc.Router.EventType.ROUTE_EXPIRED, path: fragment});
     goog.array.forEach(this.routes_ || [], function(route) {
       this.runRouteIfMatches_(route, fragment);
     }, this);

--- a/router.js
+++ b/router.js
@@ -115,7 +115,11 @@ mvc.Router.prototype.runRouteIfMatches_ = function(route, fragment) {
 mvc.Router.prototype.onChange_ = function() {
   var fragment = this.history_.getToken();
   if (fragment != this.currentFragment_) {
-    this.dispatchEvent({type: mvc.Router.EventType.ROUTE_EXPIRED, path: fragment});
+    this.dispatchEvent({
+        type: mvc.Router.EventType.ROUTE_EXPIRED, 
+        previous: this.currentFragment_,
+        current: fragment
+    });
     goog.array.forEach(this.routes_ || [], function(route) {
       this.runRouteIfMatches_(route, fragment);
     }, this);

--- a/router.js
+++ b/router.js
@@ -61,6 +61,14 @@ mvc.Router.prototype.navigate = function(fragment) {
   this.history_.setToken(fragment);
 };
 
+/**
+ * returns current routed fragment
+ * @return {string} routed fragment.
+ */
+mvc.Router.prototype.getFragment = function() {
+  return this.currentFragment_;
+}
+
 
 /**
  * define route as string or regex. /:abc/ will pass "abc" through as an

--- a/router.js
+++ b/router.js
@@ -61,6 +61,10 @@ mvc.Router.prototype.navigate = function(fragment) {
   this.history_.setToken(fragment);
 };
 
+mvc.Router.prototype.getFragment = function() {
+  return this.currentFragment_;
+}
+
 
 /**
  * define route as string or regex. /:abc/ will pass "abc" through as an

--- a/router.js
+++ b/router.js
@@ -36,10 +36,10 @@ mvc.Router = function(opt_noFragment, opt_blankPage, opt_input, opt_iframe) {
     this.history_.setUseFragment(!opt_noFragment);
   goog.events.listen(this.history_, goog.history.EventType.NAVIGATE,
       this.onChange_, false, this);
-  this.history_.setEnabled(true);
   this.routes_ = [];
+  this.currentFragment_ = "";
+  this.history_.setEnabled(true);
 };
-
 
 /**
  * pass through the fragment for the URL
@@ -69,19 +69,36 @@ mvc.Router.prototype.route = function(route, fn, opt_context) {
             .replace(/\\\]/g, ')?')
             .replace(/\\\{/g, '(?:')
             .replace(/\\\}/g, ')?') + '$');
-  this.routes_.push({route: route, callback: fn, context: opt_context});
+  var completeRoute = {
+    route: route, 
+    callback: fn, 
+    context: opt_context
+  };
+  this.runRouteIfMatches_(completeRoute, this.currentFragment_);
+  this.routes_.push(completeRoute);
 };
 
+/**
+ * run route callback if route regexp matches fragment
+ * @param {Object} route Route object with context and route regexp.
+ * @param {String} fragment URI fragment to match with.
+ */
+mvc.Router.prototype.runRouteIfMatches_ = function(route, fragment) {
+  var args = route.route.exec(fragment);
+  if (args) {
+    route.callback.apply(route.context, args);
+  }
+}
 
 /**
  * @private
  */
 mvc.Router.prototype.onChange_ = function() {
   var fragment = this.history_.getToken();
-  goog.array.forEach(this.routes_ || [], function(route) {
-    var args = route.route.exec(fragment);
-    if (!args)
-      return;
-    route.callback.apply(route.context, args);
-  }, this);
+  if (fragment != this.currentFragment_) {
+    goog.array.forEach(this.routes_ || [], function(route) {
+      this.runRouteIfMatches_(route, fragment);
+    }, this);
+    this.currentFragment_ = fragment;
+  }
 };

--- a/tests/router_test.js
+++ b/tests/router_test.js
@@ -85,6 +85,52 @@ var testRouteGlobalScope = function() {
     router.navigate('/test');
 };
 
+var testRouteExpiredEventTrigger = function() {
+    var eventTriggered = false,
+        startRoute = '/test_start';
+
+    router.navigate(startRoute);
+    var listener = goog.events.listenOnce(router, mvc.Router.EventType.ROUTE_EXPIRED, 
+        function(event) {
+            assertEquals(event.type, mvc.Router.EventType.ROUTE_EXPIRED);
+           assertEquals(event.previous, startRoute);
+           assertEquals(event.current, endRoute);
+            eventTriggered = true;     
+        }, false);
+
+    var endRoute = '/test_complete';
+    router.navigate(endRoute);
+    assertTrue(eventTriggered);
+};
+
+var testAddressParsedAfterAdding = function() {
+    var startRoute = '/testForParse',
+        routed = false;
+
+    router.navigate(startRoute);
+    router.route(startRoute, function() {
+        routed = true;
+    });
+
+    assertTrue(routed);
+};
+
+/**
+ * Google chrome runs both 'popstart' and 'hashchange' events, that cause route to run twice.
+ */
+var testRouteExecutedOnceOnly = function() {
+    var executeRoute = 'routeToExecute',
+        executionTimes = 0;
+
+    router.route(executeRoute, function() {
+        executionTimes++;
+    });
+
+    router.navigate(executeRoute);
+   assertEquals(executionTimes, 1);
+}
+
+
 testCase = new goog.testing.ContinuationTestCase();
 testCase.autoDiscoverTests();
 G_testRunner.initialize(testCase);


### PR DESCRIPTION
I've made some improvements while was trying to apply routing system:

1) When user changes hash value in address bar in Chrome, browser emits "popstate" and "hashchange" events with the same hash value, so router.onChange_ handler runs twice. Added router.currentFragment check to prevent this.
2) Firefox doesn't emit "popstate" event at page load, so if address already contains any hash, it is not routed after adding routers. Added current fragment check when adding router.
3) If main route task is not to render page content, but to show a popup window on a specified hash value (like login popup) it is necessary to hide this popup when route changes. So, I added "route expired" event to router, to catch route change.
